### PR TITLE
Fix Timestamp field to match default kibana name

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -90,7 +90,7 @@ func (hook *ElasticHook) Fire(entry *logrus.Entry) error {
 
 	msg := struct {
 		Host      string
-		Timestamp string
+		Timestamp string `json:"@timestamp"`
 		Message   string
 		Data      logrus.Fields
 		Level     string


### PR DESCRIPTION
In Kibana, @timestamp is the default Time-field name
used for the time filter.  Change the JSON output
to match ("@timestamp").