### PR TITLE
Changed logrus import to lower-case

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"gopkg.in/olivere/elastic.v5"
 )


### PR DESCRIPTION
case-insensitive import collision: "github.com/Sirupsen/logrus" and "github.com/sirupsen/logrus" when using this hook in Logrus.