### PR TITLE
Update to use `github.com/olivere/elastic` for v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,11 @@ before_script:
   - sudo sysctl -w vm.max_map_count=262144
 
 before_install:
-  - docker pull sebp/elk
   - docker run -d -p 7777:9200 --name elk elasticsearch:alpine
   - docker logs elk
   - docker inspect elk
   - travis_wait 5
 
 install:
-  - go get github.com/sirupsen/logrus
-  - go get gopkg.in/olivere/elastic.v5
+  - go get -v ./...
   - travis_wait 5

--- a/hook.go
+++ b/hook.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 var (


### PR DESCRIPTION
Updating ES client to use `github.com/olivere/elastic` for ES v6 support.