### PR TITLE
trace support

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -82,6 +82,7 @@ func newHookFuncAndFireFunc(client *elastic.Client, host string, level logrus.Le
 		logrus.WarnLevel,
 		logrus.InfoLevel,
 		logrus.DebugLevel,
+		logrus.TraceLevel,
 	} {
 		if l <= level {
 			levels = append(levels, l)


### PR DESCRIPTION
This one line PR add support for sending `TraceLevel` logs to Elasticsearch. Did some basic testing and the `TraceLevel` logs now come through. Addresses #15 .

Cheers and thanks for the plugin.