### PR TITLE
Add option for using a BulkProcessor to optimize indexing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - sudo sysctl -w vm.max_map_count=262144
 
 before_install:
-  - docker run -d -p 7777:9200 --name elk elasticsearch:6.7.0
+  - docker run -p 7777:9200 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.0.0
   - docker logs elk
   - docker inspect elk
   - travis_wait 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - sudo sysctl -w vm.max_map_count=262144
 
 before_install:
-  - docker run -d -p 7777:9200 --name elk elasticsearch:alpine
+  - docker run -d -p 7777:9200 --name elk elasticsearch:6.7.0
   - docker logs elk
   - docker inspect elk
   - travis_wait 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - sudo sysctl -w vm.max_map_count=262144
 
 before_install:
-  - docker run -p 7777:9200 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.0.0
+  - docker run -d -p 7777:9200 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.0.0
   - docker logs elk
   - docker inspect elk
   - travis_wait 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - sudo sysctl -w vm.max_map_count=262144
 
 before_install:
-  - docker run -d -p 7777:9200 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.0.0
+  - docker run -d -p 7777:9200 -e "discovery.type=single-node" --name elk docker.elastic.co/elasticsearch/elasticsearch:7.0.0
   - docker logs elk
   - docker inspect elk
   - travis_wait 5

--- a/hook.go
+++ b/hook.go
@@ -19,7 +19,7 @@ var (
 // IndexNameFunc get index name
 type IndexNameFunc func() string
 
-type fireFunc func(entry *logrus.Entry, hook *ElasticHook, indexName string) error
+type fireFunc func(entry *logrus.Entry, hook *ElasticHook) error
 
 // ElasticHook is a logrus
 // hook for ElasticSearch
@@ -33,7 +33,15 @@ type ElasticHook struct {
 	fireFunc  fireFunc
 }
 
-// NewElasticHook creates new hook
+type message struct {
+		Host      string
+		Timestamp string `json:"@timestamp"`
+		Message   string
+		Data      logrus.Fields
+		Level     string
+}
+
+// NewElasticHook creates new hook.
 // client - ElasticSearch client using gopkg.in/olivere/elastic.v5
 // host - host of system
 // level - log level
@@ -42,13 +50,22 @@ func NewElasticHook(client *elastic.Client, host string, level logrus.Level, ind
 	return NewElasticHookWithFunc(client, host, level, func() string { return index })
 }
 
-// NewAsyncElasticHook creates new  hook with asynchronous log
+// NewAsyncElasticHook creates new  hook with asynchronous log.
 // client - ElasticSearch client using gopkg.in/olivere/elastic.v5
 // host - host of system
 // level - log level
 // index - name of the index in ElasticSearch
 func NewAsyncElasticHook(client *elastic.Client, host string, level logrus.Level, index string) (*ElasticHook, error) {
 	return NewAsyncElasticHookWithFunc(client, host, level, func() string { return index })
+}
+
+// NewBulkProcessorElasticHook creates new hook that uses a bulk processor for indexing.
+// client - ElasticSearch client using gopkg.in/olivere/elastic.v5
+// host - host of system
+// level - log level
+// index - name of the index in ElasticSearch
+func NewBulkProcessorElasticHook(client *elastic.Client, host string, level logrus.Level, index string) (*ElasticHook, error) {
+	return NewBulkProcessorElasticHookWithFunc(client, host, level, func() string { return index })
 }
 
 // NewElasticHookWithFunc creates new hook with
@@ -71,6 +88,22 @@ func NewElasticHookWithFunc(client *elastic.Client, host string, level logrus.Le
 // indexFunc - function providing the name of index
 func NewAsyncElasticHookWithFunc(client *elastic.Client, host string, level logrus.Level, indexFunc IndexNameFunc) (*ElasticHook, error) {
 	return newHookFuncAndFireFunc(client, host, level, indexFunc, asyncFireFunc)
+}
+
+// NewBulkProcessorElasticHookWithFunc creates new hook with
+// function that provides the index name. This is useful if the index name is
+// somehow dynamic especially based on time that uses a bulk processor for
+// indexing.
+// client - ElasticSearch client using gopkg.in/olivere/elastic.v5
+// host - host of system
+// level - log level
+// indexFunc - function providing the name of index
+func NewBulkProcessorElasticHookWithFunc(client *elastic.Client, host string, level logrus.Level, indexFunc IndexNameFunc) (*ElasticHook, error) {
+	fireFunc, err := makeBulkFireFunc(client)
+	if err != nil {
+	  return nil, err
+	}
+	return newHookFuncAndFireFunc(client, host, level, indexFunc, fireFunc)
 }
 
 func newHookFuncAndFireFunc(client *elastic.Client, host string, level logrus.Level, indexFunc IndexNameFunc, fireFunc fireFunc) (*ElasticHook, error) {
@@ -123,15 +156,15 @@ func newHookFuncAndFireFunc(client *elastic.Client, host string, level logrus.Le
 // Fire is required to implement
 // Logrus hook
 func (hook *ElasticHook) Fire(entry *logrus.Entry) error {
-	return hook.fireFunc(entry, hook, hook.index())
+	return hook.fireFunc(entry, hook)
 }
 
-func asyncFireFunc(entry *logrus.Entry, hook *ElasticHook, indexName string) error {
-	go syncFireFunc(entry, hook, hook.index())
+func asyncFireFunc(entry *logrus.Entry, hook *ElasticHook) error {
+	go syncFireFunc(entry, hook)
 	return nil
 }
 
-func syncFireFunc(entry *logrus.Entry, hook *ElasticHook, indexName string) error {
+func createMessage(entry *logrus.Entry, hook *ElasticHook) *message {
 	level := entry.Level.String()
 
 	if e, ok := entry.Data[logrus.ErrorKey]; ok && e != nil {
@@ -140,28 +173,42 @@ func syncFireFunc(entry *logrus.Entry, hook *ElasticHook, indexName string) erro
 		}
 	}
 
-	msg := struct {
-		Host      string
-		Timestamp string `json:"@timestamp"`
-		Message   string
-		Data      logrus.Fields
-		Level     string
-	}{
+	return &message{
 		hook.host,
 		entry.Time.UTC().Format(time.RFC3339Nano),
 		entry.Message,
 		entry.Data,
 		strings.ToUpper(level),
 	}
+}
 
+func syncFireFunc(entry *logrus.Entry, hook *ElasticHook) error {
 	_, err := hook.client.
 		Index().
 		Index(hook.index()).
 		Type("log").
-		BodyJson(msg).
+		BodyJson(*createMessage(entry, hook)).
 		Do(hook.ctx)
 
 	return err
+}
+
+// Create closure with bulk processor tied to fireFunc.
+func makeBulkFireFunc(client *elastic.Client) (fireFunc, error) {
+	processor, err := client.BulkProcessor().
+		Name("elogrus.v3.bulk.processor").
+		Workers(2).
+		FlushInterval(time.Second).
+		Do(context.Background())
+
+	return func(entry *logrus.Entry, hook *ElasticHook) error {
+		r := elastic.NewBulkIndexRequest().
+			Index(hook.index()).
+			Type("log").
+			Doc(*createMessage(entry, hook))
+		processor.Add(r)
+		return nil
+	}, err
 }
 
 // Levels Required for logrus hook implementation

--- a/hook_test.go
+++ b/hook_test.go
@@ -36,7 +36,7 @@ func TestAsyncHook(t *testing.T) {
 }
 
 func TestBulkProcessorHook(t *testing.T) {
-	hookTest(NewBulkProcessorElasticHook, "async-log", t)
+	hookTest(NewBulkProcessorElasticHook, "bulk-log", t)
 }
 
 func hookTest(hookfunc NewHookFunc, indexName string, t *testing.T) {
@@ -82,8 +82,13 @@ func hookTest(hookfunc NewHookFunc, indexName string, t *testing.T) {
 		Query(termQuery).
 		Do(context.TODO())
 
-	if searchResult.Hits.TotalHits != int64(samples) {
-		t.Errorf("Not all logs pushed to elastic: expected %d got %d", samples, searchResult.Hits.TotalHits)
+	if err != nil {
+		t.Errorf("Search error: %v", err)
+		t.FailNow()
+	}
+
+	if searchResult.TotalHits() != int64(samples) {
+		t.Errorf("Not all logs pushed to elastic: expected %d got %d", samples, searchResult.TotalHits())
 		t.FailNow()
 	}
 }
@@ -120,7 +125,7 @@ func TestError(t *testing.T) {
 		Query(termQuery).
 		Do(context.TODO())
 
-	if !(searchResult.Hits.TotalHits >= 1) {
+	if !(searchResult.TotalHits() >= int64(1)) {
 		t.Error("No log created")
 		t.FailNow()
 	}

--- a/hook_test.go
+++ b/hook_test.go
@@ -35,6 +35,10 @@ func TestAsyncHook(t *testing.T) {
 	hookTest(NewAsyncElasticHook, "async-log", t)
 }
 
+func TestBulkProcessorHook(t *testing.T) {
+	hookTest(NewBulkProcessorElasticHook, "async-log", t)
+}
+
 func hookTest(hookfunc NewHookFunc, indexName string, t *testing.T) {
 	if r, err := http.Get("http://127.0.0.1:7777"); err != nil {
 		log.Fatal("Elastic not reachable")
@@ -109,8 +113,7 @@ func TestError(t *testing.T) {
 		Error("Failed to handle invalid api response")
 
 	// Allow time for data to be processed.
-	time.Sleep(1 * time.Second)
-
+	time.Sleep(1 * time.Second) 
 	termQuery := elastic.NewTermQuery("Host", "localhost")
 	searchResult, err := client.Search().
 		Index("errorlog").


### PR DESCRIPTION
This change adds a new logger type which leverages a BulkProcessor for indexing. Details about the processor here: https://github.com/olivere/elastic/wiki/BulkProcessor

I also fixed the travis build. Interestingly even with the small test which indexes 100 documents the BulkProcessor already has a measurable performance difference:

sync | async | bulk
-------|---------|--------
3.54s | 3.16s | 2.77s

https://travis-ci.org/winder/elogrus/jobs/523660438