### PR TITLE
fix error when using bulk

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -197,7 +197,6 @@ func syncFireFunc(entry *logrus.Entry, hook *ElasticHook) error {
 	_, err := hook.client.
 		Index().
 		Index(hook.index()).
-		Type("log").
 		BodyJson(*createMessage(entry, hook)).
 		Do(hook.ctx)
 
@@ -215,7 +214,6 @@ func makeBulkFireFunc(client *elastic.Client) (fireFunc, error) {
 	return func(entry *logrus.Entry, hook *ElasticHook) error {
 		r := elastic.NewBulkIndexRequest().
 			Index(hook.index()).
-			Type("log").
 			Doc(*createMessage(entry, hook))
 		processor.Add(r)
 		return nil


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20079674/119984567-1e86ac80-bff4-11eb-9368-638dffdaea44.png)
Es 7.x:  
1. using bulk api
2. type!='_ doc '
3. index match one template
Will report an error, like this:
**Rejecting mapping update to [test_access] as the final mapping would have more than 1 type: [_doc, log]**
